### PR TITLE
fix for xdebug_break and $content

### DIFF
--- a/classes/local/hooks/output/before_standard_footer_html_generation.php
+++ b/classes/local/hooks/output/before_standard_footer_html_generation.php
@@ -33,7 +33,6 @@ class before_standard_footer_html_generation {
      */
     public static function callback(\core\hook\output\before_standard_footer_html_generation $hook): void {
         global $DB, $OUTPUT;
-        xdebug_break();
 
         if (! get_config('tool_quizui', 'enabled')) {
           //  return;
@@ -117,7 +116,6 @@ class before_standard_footer_html_generation {
     * @return string
     */
    public static function toggle_checkbox(string $elementid, string $checkboxlabel): string {
-       xdebug_break();
        $showall = optional_param('showall', '', PARAM_TEXT);
        if ($showall == "true") {
            $checkedstatus = "checked=true";

--- a/classes/local/hooks/output/before_standard_footer_html_generation.php
+++ b/classes/local/hooks/output/before_standard_footer_html_generation.php
@@ -103,6 +103,7 @@ class before_standard_footer_html_generation {
     }
     public static function quiz_page_edit() {
         $elementstohide = get_config('tool_quizui', 'elementstohide');
+        $content = '';
         $content .= self::hide_elements($elementstohide);
         return $content;
     }


### PR DESCRIPTION
Removed xdebug_break so it can be installed on servers without xdebug, and a quick fix for undefined variable $content (I'm not sure if this is the right way to do it)

"Warning: Undefined variable $content in admin/tool/quizui/classes/local/hooks/output/before_standard_footer_html_generation.php on line 107"